### PR TITLE
Harst/page in description

### DIFF
--- a/src/confluence_todoist/cli.py
+++ b/src/confluence_todoist/cli.py
@@ -88,9 +88,9 @@ def main(since):
         page = confluence.get_page_by_id(task["pageId"])
         page_title = page["title"]
         page_link = page["_links"]["base"] + page["_links"]["webui"]
-        full_task_text = f"{task_text} [{page_title}]({page_link})"
-        tqdm.tqdm.write(full_task_text)
-        todoist.add_confluence_task(full_task_text)
+        link_text = f"[{page_title}]({page_link})"
+        tqdm.tqdm.write(task_text)
+        todoist.add_confluence_task(task_text, link_text)
     save_timestamp()
 
 

--- a/src/confluence_todoist/todoist.py
+++ b/src/confluence_todoist/todoist.py
@@ -40,9 +40,10 @@ class TodoistConfluence(TodoistAPI):
             section_name=config["section_name"],
         )
 
-    def add_confluence_task(self, text):
+    def add_confluence_task(self, text, description):
         task = self.add_task(
             content=text,
+            description=description,
             project_id=self.project_id,
             section_id=self.section_id,
         )


### PR DESCRIPTION
I think tasks look a bit cleaner if the page that the task appears on is not appended to the task text but instead neatly stored away in the description. 